### PR TITLE
Add menu page

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -97,6 +97,15 @@ module.exports = {
       },
       __key: 'about'
     },
+    {
+      resolve: 'gatsby-source-filesystem',
+      options: {
+        name: 'menu',
+        path: `${__dirname}/src/menu/`
+      },
+      __key: 'menu'
+    },
+    'gatsby-transformer-yaml',
     'gatsby-plugin-offline', // after manifest plugin
     {
       resolve: 'gatsby-plugin-no-javascript-utils',

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -150,13 +150,19 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     reporter.panicOnBuild(`Error while running menu validation GraphQL query.`);
     return;
   }
+  if (!menuResult.data.menuYaml) {
+    reporter.panicOnBuild(
+      `Menu data not found. Is src/menu/menu.yml present and being sourced as a menuYaml node?`
+    );
+    return;
+  }
   const knownSlugs = new Set(
     menuResult.data.allMarkdownRemark.edges
       .map((edge) => edge.node.fields && edge.node.fields.slug)
       .filter(Boolean)
       .map((slug) => slug.replace(/^\//, ''))
   );
-  const menuSections = (menuResult.data.menuYaml && menuResult.data.menuYaml.sections) || [];
+  const menuSections = menuResult.data.menuYaml.sections || [];
   menuSections.forEach((section) => {
     (section.items || []).forEach((item) => {
       if (item.recipe && !knownSlugs.has(item.recipe)) {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -125,6 +125,48 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     });
   });
 
+  // Validate that every menu item's `recipe:` reference resolves to a known markdown slug.
+  const menuResult = await graphql(`{
+    menuYaml {
+      sections {
+        name
+        items {
+          name
+          recipe
+        }
+      }
+    }
+    allMarkdownRemark {
+      edges {
+        node {
+          fields {
+            slug
+          }
+        }
+      }
+    }
+  }`);
+  if (menuResult.errors) {
+    reporter.panicOnBuild(`Error while running menu validation GraphQL query.`);
+    return;
+  }
+  const knownSlugs = new Set(
+    menuResult.data.allMarkdownRemark.edges
+      .map((edge) => edge.node.fields && edge.node.fields.slug)
+      .filter(Boolean)
+      .map((slug) => slug.replace(/^\//, ''))
+  );
+  const menuSections = (menuResult.data.menuYaml && menuResult.data.menuYaml.sections) || [];
+  menuSections.forEach((section) => {
+    (section.items || []).forEach((item) => {
+      if (item.recipe && !knownSlugs.has(item.recipe)) {
+        reporter.panicOnBuild(
+          `Menu item "${item.name}" in section "${section.name}" references recipe "${item.recipe}", but no such slug exists. Check src/menu/menu.yml.`
+        );
+      }
+    });
+  });
+
   return null;
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "gatsby-source-filesystem": "^4.19.0",
         "gatsby-transformer-remark": "^5.19.0",
         "gatsby-transformer-sharp": "^4.19.0",
+        "gatsby-transformer-yaml": "^4.25.0",
         "lodash": "^4.17.21",
         "netlify-cms-app": "^2.15.38",
         "prettier": "^2.3.2",
@@ -13164,6 +13165,59 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/gatsby-transformer-yaml": {
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-yaml/-/gatsby-transformer-yaml-4.25.0.tgz",
+      "integrity": "sha512-upmV5yAqvyDE7WvpMtG0LWlTLHk1lFivP82iL9iwKHRf/bn21iAafiFADyh0RCENnXbK0xxY4mM8UDvAXu3v3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "js-yaml": "^3.14.1",
+        "lodash": "^4.17.21",
+        "unist-util-select": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0-next"
+      }
+    },
+    "node_modules/gatsby-transformer-yaml/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/gatsby-transformer-yaml/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/gatsby-transformer-yaml/node_modules/nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "~1.0.0"
+      }
+    },
+    "node_modules/gatsby-transformer-yaml/node_modules/unist-util-select": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-1.5.0.tgz",
+      "integrity": "sha512-/Ukg/X76ljCVYbisAGJm0HOgy3MfYmjAdVOYUfBleuTtOmRZVzbW7+ZAQqJQi6ObITtcpRv7uNwoUG1RF7vJ9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "css-selector-parser": "^1.1.0",
+        "debug": "^2.2.0",
+        "nth-check": "^1.0.1"
+      }
     },
     "node_modules/gatsby-worker": {
       "version": "1.19.0",
@@ -36462,6 +36516,50 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "gatsby-transformer-yaml": {
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-yaml/-/gatsby-transformer-yaml-4.25.0.tgz",
+      "integrity": "sha512-upmV5yAqvyDE7WvpMtG0LWlTLHk1lFivP82iL9iwKHRf/bn21iAafiFADyh0RCENnXbK0xxY4mM8UDvAXu3v3g==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "js-yaml": "^3.14.1",
+        "lodash": "^4.17.21",
+        "unist-util-select": "^1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
+        "nth-check": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+          "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+          "requires": {
+            "boolbase": "~1.0.0"
+          }
+        },
+        "unist-util-select": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-1.5.0.tgz",
+          "integrity": "sha512-/Ukg/X76ljCVYbisAGJm0HOgy3MfYmjAdVOYUfBleuTtOmRZVzbW7+ZAQqJQi6ObITtcpRv7uNwoUG1RF7vJ9Q==",
+          "requires": {
+            "css-selector-parser": "^1.1.0",
+            "debug": "^2.2.0",
+            "nth-check": "^1.0.1"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gatsby-source-filesystem": "^4.19.0",
     "gatsby-transformer-remark": "^5.19.0",
     "gatsby-transformer-sharp": "^4.19.0",
+    "gatsby-transformer-yaml": "^4.25.0",
     "lodash": "^4.17.21",
     "netlify-cms-app": "^2.15.38",
     "prettier": "^2.3.2",

--- a/src/components/layout/index.jsx
+++ b/src/components/layout/index.jsx
@@ -29,6 +29,9 @@ export default function Layout({ children }) {
             <Title />
           </div>
           <div css={styles.navLinksContainer}>
+            <Link to={'/menu'} css={styles.navLink} activecss={String(styles.activeNavLink)}>
+              menu
+            </Link>
             <Link to={'/principles'} css={styles.navLink} activecss={String(styles.activeNavLink)}>
               principles
             </Link>

--- a/src/menu/menu.yml
+++ b/src/menu/menu.yml
@@ -1,0 +1,39 @@
+sections:
+  - name: Appetizers
+    items:
+      - name: Chicken Wings
+        description: Crispy, savory baked wings.
+        recipe: recipes/baked-chicken-wings
+      - name: Tomato and Egg
+        description: Comfort food classic, equally good over rice or noodles.
+        recipe: recipes/tomato-and-egg
+
+  - name: Soups
+    items:
+      - name: Pork and Lotus Root Soup
+        description: Slow-simmered, warming.
+        recipe: recipes/pork-lotus-root-soup
+
+  - name: Noodles
+    items:
+      - name: Hand-pulled Noodles
+        description: Chewy, hand-stretched, made fresh.
+        recipe: recipes/hand-pulled-noodles
+      - name: Old Buddy Noodles
+        description: A weeknight favorite.
+        recipe: recipes/old-buddy-noodles
+
+  - name: Mains
+    items:
+      - name: Oven-baked Salmon
+        description: Simple, light, mostly hands-off.
+        recipe: recipes/oven-baked-salmon
+      - name: Steamed Lobster
+        description: Sweet, clean, special-occasion.
+        recipe: recipes/steamed-lobster
+      - name: Chestnut Braised Chicken
+        description: Comforting, slightly sweet.
+        recipe: recipes/chestnut-braised-chicken
+      - name: Dumplings
+        description: Hand-folded, served with dipping sauce.
+        recipe: recipes/cooking-dumplings

--- a/src/pages/menu.jsx
+++ b/src/pages/menu.jsx
@@ -1,0 +1,50 @@
+import { graphql, Link } from 'gatsby';
+import React from 'react';
+
+import Layout from '../components/layout';
+import SEO from '../components/seo';
+
+export default function Menu({ data }) {
+  const sections = (data.menuYaml && data.menuYaml.sections) || [];
+  return (
+    <Layout>
+      <SEO title="menu" path="/menu" />
+      <h1>menu</h1>
+      <p>A loose list of things I might cook. Browse, then let me know what sounds good.</p>
+      {sections.map((section) => (
+        <section key={section.name}>
+          <h2>{section.name}</h2>
+          <ul>
+            {(section.items || []).map((item) => (
+              <li key={item.name}>
+                <strong>{item.name}</strong>
+                {item.description && <span> — {item.description}</span>}
+                {item.recipe && (
+                  <span>
+                    {' '}
+                    <Link to={`/${item.recipe}`}>view recipe →</Link>
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </Layout>
+  );
+}
+
+export const pageQuery = graphql`
+  query MenuPageQuery {
+    menuYaml {
+      sections {
+        name
+        items {
+          name
+          description
+          recipe
+        }
+      }
+    }
+  }
+`;

--- a/src/pages/menu.jsx
+++ b/src/pages/menu.jsx
@@ -17,14 +17,10 @@ export default function Menu({ data }) {
           <ul>
             {(section.items || []).map((item) => (
               <li key={item.name}>
-                <strong>{item.name}</strong>
+                <strong>
+                  {item.recipe ? <Link to={`/${item.recipe}`}>{item.name}</Link> : item.name}
+                </strong>
                 {item.description && <span> — {item.description}</span>}
-                {item.recipe && (
-                  <span>
-                    {' '}
-                    <Link to={`/${item.recipe}`}>view recipe →</Link>
-                  </span>
-                )}
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary

- Adds a `/menu` page styled conceptually like a takeout menu: sections (Appetizers, Soups, Noodles, Mains) with items that each have a name, short description, and an optional link to the corresponding recipe.
- Driven by a single YAML file (`src/menu/menu.yml`) sourced via `gatsby-transformer-yaml`. Curated independently from the recipe collection — recipes don't need any new fields, and not every recipe shows up.
- Build-time validation in `gatsby-node.js` fails the build if any `recipe:` reference points at a slug that doesn't exist, or if the menu data source is missing entirely.

The ordering form for guests is intentionally deferred. Pictures are deferred too.

## Test plan

- [ ] `npx gatsby build` succeeds with the current `menu.yml` (or `npm run build` if you don't mind prettier reformatting `writing/`).
- [ ] Visit `/menu` in `gatsby serve` or `gatsby develop`. Confirm 4 sections render with all 9 items, each with description and "view recipe →" link.
- [ ] Click a few "view recipe →" links; confirm they navigate to the existing recipe pages (no 404s).
- [ ] Confirm the `menu` link appears in the nav across the rest of the site and clicking it works.
- [ ] (Negative path) Temporarily change one `recipe:` value in `src/menu/menu.yml` to a bogus slug; run `npx gatsby build` and confirm it fails with a clear panic naming the item, section, and bad slug. Revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)